### PR TITLE
Update to the most recent version (v1.2.0) in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In the mean time, you can install it using the git package syntax, which the Git
 ```
 packages:
   - git: https://gitlab.com/gitlab-data/snowflake_spend.git
-    revision: v1.1.0
+    revision: v1.2.0
 ```
 
 You will need to update your `dbt_project.yml` to enable this package.


### PR DESCRIPTION
1.1.0 is broken on 0.19.0 and I noticed that 1.2.0 is actually the newest version that works with 0.19.0