### PR TITLE
Update packages.yml

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
- - package: fishtown-analytics/dbt_utils
+ - package: dbt-labs/dbt_utils
    version: '>=0.1.25'

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: '>0.1.25'
+   version: '>0.8.0'

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: '>0.2.0'
+   version: 0.8.0

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: '>0.8.0'
+   version: '>0.2.0'

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: '>=0.1.25'
+   version: '>0.1.25'

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: 0.8.0
+   version: '>=0.1.25'


### PR DESCRIPTION
Fishtown has re-branded as dbt-labs.  This renames the dbt_utils package to match the name change used by other packages.