### PR TITLE
Update Package Dependencies to use the dbt-labs repo

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
- - package: fishtown-analytics/dbt_utils
+ - package: dbt-labs/dbt_utils
    version: '>=0.1.25'


### PR DESCRIPTION
current version points to fishtown-analytics, which no longer exists.