### PR TITLE
Fix/update the name of the utils package

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
- - package: fishtown-analytics/dbt_utils
+ - package: dbt-labs/dbt_utils
    version: '>=0.1.25'


### PR DESCRIPTION
With the rebranding of Fishtown Analytics to dbt Labs, we changed the name of our github organization and thus need to update the dbt_utils package name to reference dbt_labs. 

[This is causing issues with users of the this package as seen here](https://getdbt.slack.com/archives/CJN7XRF1B/p1627942656052100) so wanted to fix it. 