### PR TITLE
Update packages.yml

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
- - package: fishtown-analytics/dbt_utils
-   version: '>=0.1.25'
+ - package: dbt-labs/dbt_utils
+   version: '>=0.8.4'


### PR DESCRIPTION
I think the old 'fishtown-analytics' path is causing problems when you try to 'dbt deps' this package since dbt doesn't like the two 'version' of git-lab utils: "Found duplicate project "dbt_utils". This occurs when a dependency has the same project name as some other dependency. Code: 10006"