### PR TITLE
Updated configurations

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,9 +3,9 @@ version: '1.0'
 config-version: 2
 require-dbt-version: ">=0.17.0"
 
-source-paths: ["models"]   # paths with source code to compile
+model-paths: ["models"]   # paths with source code to compile
 analysis-paths: ["analysis"] # path with analysis files which are compiled, but not run
 target-path: "target"      # path for compiled code
 clean-targets: ["target"]  # directories removed by the clean task
 test-paths: ["test"]       # where to store test results
-data-paths: ["data"]       # load CSVs from this directory with `dbt seed`
+seed-paths: ["seeds"]       # load CSVs from this directory with `dbt seed`


### PR DESCRIPTION
dbt has deprecated `source-paths` and `data-paths` configs. They have both been renamed to:
`source-paths` -> model-paths: ["models"]   # paths with source code to compile
`data-paths` -> seed-paths: ["seeds"]       # load CSVs from this directory with `dbt seed`

Please update your configuration to reflect this change.